### PR TITLE
수정 : install-gemini.sh 경로 문제 해결

### DIFF
--- a/gemini/install-gemini.sh
+++ b/gemini/install-gemini.sh
@@ -45,7 +45,7 @@ if ! command -v curl &> /dev/null; then
 fi
 
 # Create installation directory
-INSTALL_DIR="usr/local/bin"
+INSTALL_DIR="/usr/local/bin"
 mkdir -p "$INSTALL_DIR"
 
 # Copy script


### PR DESCRIPTION
## 변경 사항
이 PR은 `install-gemini.sh` 스크립트의 설치 경로 문제를 수정합니다.

### 수정 내용:
- 설치 디렉토리 경로를 `INSTALL_DIR="/usr/local/bin"` 절대 경로로 명확하게 지정
- 이전에는 상대 경로로 설정되어 현재 디렉토리 내에 로컬 `usr/local/bin` 구조가 생성되는 문제가 있었음

## 관련 이슈
이 PR은 #2 를 해결합니다.

## 테스트
Ubuntu Docker 환경에서 테스트 완료