### PR TITLE
feat(ollama-server): add API to generate commit messages using diff

### DIFF
--- a/ollama/server/app.py
+++ b/ollama/server/app.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import ollama
+
+app = FastAPI()
+
+class DiffRequest(BaseModel):
+    diff: str
+
+@app.post("/generate-commit-message")
+async def generate_commit_message(request: DiffRequest):
+    print(request)
+    try:
+        prompt = (
+            "Generate a git commit message in the Conventional Commits format based on the following diff:\n\n"
+            f"{request.diff}\n\n"
+            "The format must be: <type>(<scope>): <description>\n"
+            "Where:\n"
+            "- type: one of feat, fix, docs, style, refactor, test, chore\n"
+            "- scope: a single word describing the module or area affected (e.g., auth, ui)\n"
+            "- description: a concise summary of changes (max 50 characters, lowercase)\n"
+            "Example: feat(auth): add user login functionality\n"
+            "Return only the commit message, nothing else."
+        )
+        response = ollama.generate(model="llama3", prompt=prompt)
+        return {"commit_message": response["response"].strip()}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## 설명
<!-- 이 PR에 대한 간략한 설명을 적어주세요. -->

## 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. (예: #123) -->
Closes #

## 변경 유형
<!-- 해당하는 항목에 x 표시해주세요. -->
- [ ] 버그 수정 (non-breaking change)
- [x] 새 기능 (non-breaking change)
- [ ] 주요 변경 사항 (기존 기능을 수정하는 breaking change)
- [ ] 문서 업데이트

## 작업 내용
<!-- 구현한 내용을 체크박스 형태로 작성해주세요 -->
- [x] POST /generate-commit-message API 추가
- [x] diff를 기반으로 커밋 메시지를 생성하는 기능 구현
- [x] 에러 발생 시 500 에러 반환 처리

## 테스트 방법
<!-- 변경 사항을 어떻게 테스트했는지 설명해 주세요. -->
- 로컬환경에서 Uvicorn 실행 `uvicorn app:app --reload`
- ngrok으로 실행 후 팀원들에게 테스트 요청 `ngrok http 8000`
- /docs 에서 api 테스트 실행

## 스크린샷
<!-- 필요한 경우 스크린샷을 첨부해주세요. -->

## 추가 정보
<!-- 더 알려주고 싶은 내용이 있다면 작성해주세요. -->