### PR TITLE
fixed: iss-37

### DIFF
--- a/pattern_based/autocommit
+++ b/pattern_based/autocommit
@@ -73,7 +73,12 @@ if [ "$confirm" = "y" ]; then
     git commit -m "$COMMIT_MESSAGE"
     echo "성공적으로 커밋되었습니다!"
 elif [ "$confirm" = "e" ]; then
-    read -p "새 커밋 메시지를 입력하세요: " new_message
+    tmpfile=$(mktemp)
+    echo "# 새 커밋 메시지를 입력하세요. 한 줄 이상 작성 가능합니다." > "$tmpfile"
+    echo "" >> "$tmpfile"
+    ${EDITOR:-vim} "$tmpfile"
+    new_message=$(grep -v '^#' "$tmpfile" | sed '/^\s*$/d')
+    rm "$tmpfile"
     git commit -m "$new_message"
     echo "입력하신 메시지로 커밋되었습니다!"
 else


### PR DESCRIPTION
터미널에서 한글 입력 및 제거 할 때 오류 발생하는 것을 해결하지 못해 vi 편집기를 이용하여 commit 메세지를 수정하도록 하였습니다.

## 설명
<!-- 이 PR에 대한 간략한 설명을 적어주세요. -->
edit 기능에서 한글 입력 및 한글 내용 수정시 글자가 깨지는 현상 발생
## 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 적어주세요. (예: #123) -->
Closes #37 

## 변경 유형
<!-- 해당하는 항목에 x 표시해주세요. -->
- [x] 버그 수정 (non-breaking change)
- [ ] 새 기능 (non-breaking change)
- [ ] 주요 변경 사항 (기존 기능을 수정하는 breaking change)
- [ ] 문서 업데이트

## 작업 내용
<!-- 구현한 내용을 체크박스 형태로 작성해주세요 -->
- [x] commit 메세지 작성을 vi 편집기를 이용하여 작성 

## 테스트 방법
<!-- 변경 사항을 어떻게 테스트했는지 설명해 주세요. -->
1. git staged에 commit할 내용을 올림
2. autocommit 명령어 실행
3.  edit 기능 실행
4. vi 편집기를 이용하여 commit 메세지작성
5. :wq 명령어를 입력하여 commit 메세지 작성 완료
6. git log 명령어로 commit 된 메세지 확인
## 스크린샷
<!-- 필요한 경우 스크린샷을 첨부해주세요. -->

## 추가 정보
<!-- 더 알려주고 싶은 내용이 있다면 작성해주세요. -->
터미널 환경에서 한글 입력 문제를 해결하기 힘들어서 vi 편집기를 이용하였습니다. 더 나은 방안이 있으면 말씀해주세요.
+ 해당 기능을 추가 할 경우 pattern-based 에 있는 readme.md에서 사용 방법에 vi 편집기 사용 법도 추가로 작성해주시면 감사하겠습니다.